### PR TITLE
api Get working and customer one to one updated

### DIFF
--- a/bangazon/urls.py
+++ b/bangazon/urls.py
@@ -17,6 +17,7 @@ router.register(r'orders', Orders, 'order')
 router.register(r'cart', Cart, 'cart')
 router.register(r'paymenttypes', Payments, 'payment')
 router.register(r'profile', Profile, 'profile')
+router.register(r'stores', StoresViewSet, 'store')
 
 
 # Wire up our API using automatic URL routing.

--- a/bangazonapi/models/store.py
+++ b/bangazonapi/models/store.py
@@ -7,6 +7,6 @@ from django.conf import settings
 class Store(models.Model):
     name = models.CharField(max_length=255)
     description = models.TextField(max_length=2500)
-    customer_id = models.ForeignKey(
-        "customer", on_delete=models.CASCADE, related_name="stores"
+    customer = models.OneToOneField(
+        "customer", on_delete=models.CASCADE, related_name="store_owned"
     )

--- a/bangazonapi/views/__init__.py
+++ b/bangazonapi/views/__init__.py
@@ -9,3 +9,4 @@ from .productcategory import ProductCategories
 from .lineitem import LineItems
 from .customer import Customers
 from .user import Users
+from .store import StoresViewSet

--- a/bangazonapi/views/store.py
+++ b/bangazonapi/views/store.py
@@ -1,0 +1,31 @@
+from rest_framework.decorators import action
+from bangazonapi.models.recommendation import Recommendation
+import base64
+from django.core.files.base import ContentFile
+from django.http import HttpResponseServerError
+from rest_framework.viewsets import ViewSet
+from rest_framework.response import Response
+from rest_framework import serializers
+from rest_framework import status
+from bangazonapi.models import Store
+from rest_framework.permissions import IsAuthenticatedOrReadOnly
+from rest_framework.parsers import MultiPartParser, FormParser
+
+
+class StoreSerializer(serializers.ModelSerializer):
+    """JSON serializer for stores"""
+    class Meta:
+        model = Store
+        fields = ['id', 'name', 'description', 'customer_id']
+      
+
+class StoresViewSet(ViewSet):
+    """Request handlers for Stores in the Bangazon Platform"""
+    permission_classes = (IsAuthenticatedOrReadOnly,)
+
+
+    def list(self, request): 
+        stores = Store.objects.all()
+        serializer = StoreSerializer(
+            stores, many=True, context={'request': request})
+        return Response(serializer.data)


### PR DESCRIPTION
## What?
The customer field is changed from a foreign key to a one-to-one-field on the store model. I also created the handle request to list all store objects.
## Why?
As a team, we determined that having the customer field as a one-to-one field on the store model strengthened the data integrity since a customer user can only have one store. We also needed a handle request to list all of the stores for the all-stores view.
## How?
The customer field on the store model was simply changed to be a one-to-one field. For the handle request, the list handle request was created so the client can receive a list of all the stores.
## Testing?
This update can be tested in postman
## Screenshots (optional)
0
## Anything Else?
I will need to update the serializer in the store view and expand it in order to receive the customer's name. This will be done in the near future.