### PR TITLE
Delete Cart item(s) using the trash icon

### DIFF
--- a/bangazon/urls.py
+++ b/bangazon/urls.py
@@ -10,7 +10,7 @@ from bangazonapi.views import *
 router = routers.DefaultRouter(trailing_slash=False)
 router.register(r'products', Products, 'product')
 router.register(r'productcategories', ProductCategories, 'productcategory')
-router.register(r'lineitems', LineItems, 'orderproduct')
+router.register(r'lineitems', LineItems, 'lineitem')
 router.register(r'customers', Customers, 'customer')
 router.register(r'users', Users, 'user')
 router.register(r'orders', Orders, 'order')


### PR DESCRIPTION
### Changes Made to the following files:
1. `bangazon/urls.py`

### Overview
Changed the basename parameter on line 13 to `lineitem`

### Steps To Test
1. Pull down API & Client Changes
3. Add any products to cart
4. Click the trash icon and you will see a console.log with the id of the product removed along with the product no longer being in the cart

## Related Issues

- Fixes #8 