### PR TITLE
Delete Order Feature Added

### DIFF
--- a/bangazonapi/views/cart.py
+++ b/bangazonapi/views/cart.py
@@ -11,6 +11,18 @@ from .order import OrderSerializer
 class Cart(ViewSet):
     """Shopping cart for Bangazon eCommerce"""
 
+    def create_empty_order(self, request):
+        """
+        Used when the user deletes their order, this function will create a new empty order 
+        """
+
+        current_user = Customer.objects.get(user=request.auth.user)
+        new_order = Order()
+        new_order.created_date = datetime.datetime.now()
+        new_order.customer = current_user
+        new_order.save()
+        return new_order
+
     def create(self, request):
         """
         @api {POST} /cart POST new line items to cart
@@ -59,8 +71,8 @@ class Cart(ViewSet):
             order=open_order
         )[0]
         line_item.delete()
-
         return Response({}, status=status.HTTP_204_NO_CONTENT)
+        
 
 
     def list(self, request):

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -15,6 +15,7 @@ from bangazonapi.models import Recommendation
 from .product import ProductSerializer
 from .order import OrderSerializer, Order
 from django.contrib.auth.models import User
+from .cart import Cart
 
 
 class Profile(ViewSet):
@@ -130,12 +131,18 @@ class Profile(ViewSet):
                 line_items = OrderProduct.objects.filter(order=open_order)
                 line_items.delete()
                 open_order.delete()
+
+                cart_viewset = Cart() # Get access to cart methods 
+                cart_viewset.request = request # gives cart the same request data the DELETE has 
+                cart_viewset.create_empty_order(request)
+
             except Order.DoesNotExist as ex:
                 return Response(
                     {"message": ex.args[0]}, status=status.HTTP_404_NOT_FOUND
                 )
 
             return Response({}, status=status.HTTP_204_NO_CONTENT)
+            
 
         if request.method == "GET":
             """


### PR DESCRIPTION
Completed ticket #32 that allows the customer to delete their entire order 

## Changes
#### views/cart.py
Created the `create_empty_order` to handle creating an empty order when the user deletes their current order to avoid "404 (Not Found)" from the Cart GET request  

#### views/profile.py
Added to the `DELETE` method a couple lines of code that use the above ^ to create a new empty order once the previous order has been deleted.

## Testing

- [ ] Pull down API & Client side changes 
- [ ] Spin up servers 
- [ ] add products to your cart 
- [ ] click "Delete Order"

The page will refresh and the items inside the cart will be gone and a new order created

You can double check this by taking note of the current order number in the DB "Orders" table before you click delete then after the reload, refresh the table and you will notice the order id increased by 1.



## Related Issues
- Added #32 