### PR TITLE
Feature: update store serializer

### DIFF
--- a/bangazonapi/models/customer.py
+++ b/bangazonapi/models/customer.py
@@ -5,7 +5,7 @@ from django.contrib.auth.models import User
 
 class Customer(models.Model):
 
-    user = models.OneToOneField(User, on_delete=models.DO_NOTHING,)
+    user = models.OneToOneField(User, on_delete=models.DO_NOTHING)
     phone_number = models.CharField(max_length=15)
     address = models.CharField(max_length=55)
     # store = models.ForeignKey(Store, on_delete=models.SET_NULL, null=True, related_name='owner')

--- a/bangazonapi/models/customer.py
+++ b/bangazonapi/models/customer.py
@@ -8,7 +8,7 @@ class Customer(models.Model):
     user = models.OneToOneField(User, on_delete=models.DO_NOTHING)
     phone_number = models.CharField(max_length=15)
     address = models.CharField(max_length=55)
-    # store = models.ForeignKey(Store, on_delete=models.SET_NULL, null=True, related_name='owner')
+    #store = models.ForeignKey(Store, on_delete=models.SET_NULL, null=True, related_name='owner')
 
     @property
     def recommends(self):

--- a/bangazonapi/models/store.py
+++ b/bangazonapi/models/store.py
@@ -10,8 +10,6 @@ class Store(models.Model):
     customer = models.OneToOneField(
         Customer, on_delete=models.CASCADE, related_name="store_owned"
     )
-    description = models.CharField(max_length=255)
-
     def __str__(self):
         return self.description
 

--- a/bangazonapi/models/store.py
+++ b/bangazonapi/models/store.py
@@ -1,12 +1,14 @@
 from django.db import models
 from django.conf import settings
+from .customer import Customer
+# Import the User model if you haven't customized it
 
 
 class Store(models.Model):
     name = models.CharField(max_length=255)
     description = models.TextField(max_length=2500)
     customer = models.OneToOneField(
-        "customer", on_delete=models.CASCADE, related_name="store_owned"
+        Customer, on_delete=models.CASCADE, related_name="store_owned"
     )
     description = models.CharField(max_length=255)
 

--- a/bangazonapi/views/store.py
+++ b/bangazonapi/views/store.py
@@ -1,15 +1,23 @@
 from rest_framework.decorators import action
+from django.contrib.auth.models import User
+from rest_framework.viewsets import ViewSet
+from rest_framework.response import Response
+from rest_framework import serializers
+from rest_framework.permissions import IsAuthenticatedOrReadOnly
+from rest_framework.parsers import MultiPartParser, FormParser
 from bangazonapi.models.recommendation import Recommendation
 import base64
 from django.core.files.base import ContentFile
 from django.http import HttpResponseServerError
-from rest_framework.viewsets import ViewSet
-from rest_framework.response import Response
-from rest_framework import serializers
 from rest_framework import status
 from bangazonapi.models import Store, Product
-from rest_framework.permissions import IsAuthenticatedOrReadOnly
-from rest_framework.parsers import MultiPartParser, FormParser
+from bangazonapi.models import Customer
+
+
+class StoreUserSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Customer
+        fields = ['user_id']
 from .product import ProductSerializer
 
 
@@ -17,6 +25,7 @@ class StoreSerializer(serializers.ModelSerializer):
     """JSON serializer for stores"""
     products = serializers.SerializerMethodField()
 
+    customer = StoreUserSerializer(many=False)
     class Meta:
         model = Store
         fields = ['id', 'name', 'description', 'customer_id', 'products']

--- a/bangazonapi/views/store.py
+++ b/bangazonapi/views/store.py
@@ -12,23 +12,29 @@ from django.http import HttpResponseServerError
 from rest_framework import status
 from bangazonapi.models import Store, Product
 from bangazonapi.models import Customer
-
-
-class StoreUserSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Customer
-        fields = ['user_id']
 from .product import ProductSerializer
 
+
+class UserSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        fields = ['first_name', 'last_name']
+
+class StoreCustomerSerializer(serializers.ModelSerializer):
+    user = UserSerializer(many=False)
+
+    class Meta:
+        model = Customer
+        fields = ['user']
 
 class StoreSerializer(serializers.ModelSerializer):
     """JSON serializer for stores"""
     products = serializers.SerializerMethodField()
+    customer = StoreCustomerSerializer(many=False)
 
-    customer = StoreUserSerializer(many=False)
     class Meta:
         model = Store
-        fields = ['id', 'name', 'description', 'customer_id', 'products']
+        fields = ['id', 'name', 'description', 'customer_id', 'products', 'customer']
     
     def get_products(self, obj):
         # Check for a query parameter like ?expand=products


### PR DESCRIPTION
## What?
I created two new serializers and nested them in the primary StoreSerializer. This creates an expanded store object and allows us to display the name of the store owner in the "all stores" view.
## Why?
first_name and last_name are properties on the Django user, so the store object needed to be expanded in order to access those values for the "all stores" view. This is in ref to ticket #36
## How?
UserSerializer serializes data from the user model (first_name and last_name) and CustomerUserSerializer nests that information and expands the store object on the customer_id property.
## Testing?
Test in postman at /stores endpoint
## Screenshots (optional)
<img width="619" alt="Screenshot 2024-07-02 at 2 44 04 PM" src="https://github.com/day-cohort-70/Bangazon-API-Spicy-Boys-V2/assets/156968086/ead2dbec-6777-4af0-932f-a9bccc97bd93">

## Anything Else?
Ticket #36 is still in progress, but this PR helps limit potential blockers