### PR TITLE
BUG Fix: Complete Order Not Working 

### DIFF
--- a/bangazonapi/models/product.py
+++ b/bangazonapi/models/product.py
@@ -81,9 +81,6 @@ class Product(SafeDeleteModel):
         if len(ratings) is not 0:
             avg = total_rating / len(ratings)
             return avg
-        else:
-
-       
 
     class Meta:
         verbose_name = "product"


### PR DESCRIPTION
## Changes
#### `views/order.py`
- Did a lazy import of `Cart` to avoid circular import error 
- Retrieve the payment id from the request that is associated with the customer 
- Assigned the `payment_instance` to the DB field `payment_type`
- Created a new empty order after the user clicks `Complete Order`

## Testing
- [ ] Pull the API and Client side changes down 
- [ ] Start Servers
- [ ] Add products to cart 
- [ ] Complete Order
- [ ] Verify the Order is in the `my-orders` view
- [ ] Check the DB to make sure the payment id is in the orders table and a new order has been created under it


## Related Issues
- Fixes #33 