### PR TITLE
A user without a store can create one

### DIFF
--- a/bangazonapi/models/store.py
+++ b/bangazonapi/models/store.py
@@ -1,6 +1,8 @@
 from django.db import models
 from django.conf import settings
 from .customer import Customer
+from django.contrib.auth.models import User
+
 # Import the User model if you haven't customized it
 
 

--- a/bangazonapi/views/store.py
+++ b/bangazonapi/views/store.py
@@ -72,3 +72,25 @@ class StoresViewSet(ViewSet):
 
         except Exception as ex:
             return HttpResponseServerError(ex)
+    def create(self, request):
+        """Handle POST operations
+        
+        Returns:
+            Response -- JSON serialized store instance
+        """
+        name = request.data.get("name")
+        description = request.data.get("description")
+
+        if not name or not description:
+                return Response({"error": "Name and Description are required."}, status=status.HTTP_400_BAD_REQUEST)
+
+        try:
+            customer = Customer.objects.get(user=request.auth.user)
+        except Customer.DoesNotExist:
+            return Response({"error": "Customer not found"}, status=status.HTTP_404_NOT_FOUND)
+        
+        new_store = Store(name=name, description=description, customer=customer)
+        new_store.save()
+
+        serializer = StoreSerializer(new_store, context={"request": request})
+        return Response(serializer.data, status=status.HTTP_201_CREATED)


### PR DESCRIPTION
## What?
A user can now create a store to sell items as long as they are not the owner of any other store.
## Why?
A Bangazon user should be able to be both a buyer and a seller on the platform. If a user is not currently a seller, they can create a store and begin to list products for sale.
## How?
A logged in user who is not currently a store owner can click on the "Interested in selling?" link in the dropdown menu. They will be directed to a form that will allow them to enter the store's name and a description. After they click the save button, they will be directed to their new store view. The "interested in selling?" link in the dropdown menu will now read "view your store." A create handler was built in the StoresViewSet class.
## Testing?
Test in browser to ensure full stack application:
-run api debugger in server side
-run npm run dev in client
-make sure you are currently logged in as a user w/o a store. If you do not have a user without a store currently in your database, register a new user in the browser first and ensure that user has been added to your DB.
-In the browser, click the "interested in selling?" link from the dropdown menu.
-fill out the new store form, click save.
-You will be routed to the store view. Ensure the store has also been added to your database.
## Screenshots (optional)
0
## Anything Else?
As of this feature, a store with zero current products is listed in the all store view. I will be handling ticket #68 to ensure that only stores with products are listed in the all store view. 