### PR TITLE
Implement favorite sellers template report

### DIFF
--- a/bangazon/urls.py
+++ b/bangazon/urls.py
@@ -20,6 +20,7 @@ router.register(r'profile', Profile, 'profile')
 router.register(r'stores', StoresViewSet, 'store')
 router.register(r'storeproduct', OrderProductViewSet, basename='storeproduct')
 router.register(r'reports/favoritesellers', FavoritesReportViewSet, basename='favorites-report')
+# router.register(r'reports/favoritesellers', FavoritesReportViewSet, basename='favorites-report')
 
 
 # Wire up our API using automatic URL routing.
@@ -30,6 +31,7 @@ urlpatterns = [
     path('login', login_user),
     path('api-token-auth', obtain_auth_token),
     path('api-auth', include('rest_framework.urls', namespace='rest_framework')),
+    path('reports/favoritesellers/', FavoritesReportTemplateView.as_view(), name='favorites-report-template'),
     
     # path('storeproduct/<int:store_id>/', OrderProductViewSet.as_view({'get': 'retrieve'}, name='storeproduct')),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/bangazon/urls.py
+++ b/bangazon/urls.py
@@ -19,6 +19,7 @@ router.register(r'paymenttypes', Payments, 'payment')
 router.register(r'profile', Profile, 'profile')
 router.register(r'stores', StoresViewSet, 'store')
 router.register(r'storeproduct', OrderProductViewSet, basename='storeproduct')
+router.register(r'reports/favoritesellers', FavoritesReportViewSet, basename='favorites-report')
 
 
 # Wire up our API using automatic URL routing.
@@ -29,5 +30,6 @@ urlpatterns = [
     path('login', login_user),
     path('api-token-auth', obtain_auth_token),
     path('api-auth', include('rest_framework.urls', namespace='rest_framework')),
+    
     # path('storeproduct/<int:store_id>/', OrderProductViewSet.as_view({'get': 'retrieve'}, name='storeproduct')),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/bangazon/urls.py
+++ b/bangazon/urls.py
@@ -6,7 +6,7 @@ from rest_framework.authtoken.views import obtain_auth_token
 from bangazonapi.models import *
 from bangazonapi.views import *
 
-# pylint: disable=invalid-name
+
 router = routers.DefaultRouter(trailing_slash=False)
 router.register(r'products', Products, 'product')
 router.register(r'productcategories', ProductCategories, 'productcategory')
@@ -20,11 +20,7 @@ router.register(r'profile', Profile, 'profile')
 router.register(r'stores', StoresViewSet, 'store')
 router.register(r'storeproduct', OrderProductViewSet, basename='storeproduct')
 router.register(r'reports/favoritesellers', FavoritesReportViewSet, basename='favorites-report')
-# router.register(r'reports/favoritesellers', FavoritesReportViewSet, basename='favorites-report')
 
-
-# Wire up our API using automatic URL routing.
-# Additionally, we include login URLs for the browsable API.
 urlpatterns = [
     path('', include(router.urls)),
     path('register', register_user),
@@ -32,6 +28,6 @@ urlpatterns = [
     path('api-token-auth', obtain_auth_token),
     path('api-auth', include('rest_framework.urls', namespace='rest_framework')),
     path('reports/favoritesellers/', FavoritesReportTemplateView.as_view(), name='favorites-report-template'),
-    
-    # path('storeproduct/<int:store_id>/', OrderProductViewSet.as_view({'get': 'retrieve'}, name='storeproduct')),
+    path('inexpensiveproducts', InexpensiveProductsView.as_view(), name='inexpensive-products'),
+    path('expensiveproducts', ExpensiveProductsView.as_view(), name='expensive-products'),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/bangazonapi/models/customer.py
+++ b/bangazonapi/models/customer.py
@@ -28,7 +28,7 @@ class Customer(models.Model):
         self.__recommended = value
 
 
-    def generate_favorites_report(customer_id):
+    def generate_favorites_report(self, customer_id):
         # Fetch the customer's details
         customer = get_object_or_404(Customer, pk=customer_id)
         

--- a/bangazonapi/models/customer.py
+++ b/bangazonapi/models/customer.py
@@ -1,6 +1,7 @@
 from django.db import models
 from django.contrib.auth.models import User
-
+from django.shortcuts import get_object_or_404
+from .favorite import Favorite
 
 
 class Customer(models.Model):
@@ -25,3 +26,27 @@ class Customer(models.Model):
     @recommended.setter
     def recommended(self, value):
         self.__recommended = value
+
+
+    def generate_favorites_report(customer_id):
+        # Fetch the customer's details
+        customer = get_object_or_404(Customer, pk=customer_id)
+        
+        # Fetch all sellers favorited by this customer
+        favorites = Favorite.objects.filter(customer=customer)
+        
+        # Prepare the report data
+        report_data = {
+            "customer_name": customer.user.first_name + " " + customer.user.last_name,
+            "favorites": []
+        }
+        
+        for favorite in favorites:
+            # Assuming the Favorite model has a foreign key to a Seller model
+            seller = favorite.seller
+            report_data["favorites"].append({
+                "seller_name": seller.user.first_name + " " + seller.user.last_name,
+                "seller_details": str(seller)  # Assuming __str__ method is implemented in the Seller model
+            })
+        
+        return report_data

--- a/bangazonapi/models/favorite.py
+++ b/bangazonapi/models/favorite.py
@@ -1,6 +1,5 @@
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
-from .customer import Customer
 from .productcategory import ProductCategory
 from .orderproduct import OrderProduct
 from safedelete.models import SafeDeleteModel
@@ -8,5 +7,5 @@ from safedelete.models import SOFT_DELETE
 
 class Favorite(models.Model):
 
-    customer = models.ForeignKey(Customer, on_delete=models.DO_NOTHING,)
-    seller = models.ForeignKey(Customer, on_delete=models.DO_NOTHING, related_name='favorited_seller')
+    customer = models.ForeignKey('Customer', on_delete=models.DO_NOTHING,)
+    seller = models.ForeignKey('Customer', on_delete=models.DO_NOTHING, related_name='favorited_seller')

--- a/bangazonapi/templates/reports/favoritesellers.html
+++ b/bangazonapi/templates/reports/favoritesellers.html
@@ -1,0 +1,12 @@
+
+
+{% block content %}
+<h2>{{ customer_name }}</h2>
+<ul>
+{% for favorite in favorites %}
+<li>{{ favorite.seller_name }}</li>
+{% empty %}
+<p>No favorites found.</p>
+{% endfor %}
+</ul>
+{% endblock %}

--- a/bangazonapi/views/__init__.py
+++ b/bangazonapi/views/__init__.py
@@ -11,3 +11,4 @@ from .customer import Customers
 from .user import Users
 from .store import StoresViewSet
 from .storeproduct import OrderProductViewSet
+from .report import FavoritesReportViewSet

--- a/bangazonapi/views/__init__.py
+++ b/bangazonapi/views/__init__.py
@@ -11,4 +11,4 @@ from .customer import Customers
 from .user import Users
 from .store import StoresViewSet
 from .storeproduct import OrderProductViewSet
-from .report import FavoritesReportViewSet, FavoritesReportTemplateView
+from .report import FavoritesReportViewSet, FavoritesReportTemplateView, ExpensiveProductsView, InexpensiveProductsView

--- a/bangazonapi/views/__init__.py
+++ b/bangazonapi/views/__init__.py
@@ -11,4 +11,4 @@ from .customer import Customers
 from .user import Users
 from .store import StoresViewSet
 from .storeproduct import OrderProductViewSet
-from .report import FavoritesReportViewSet
+from .report import FavoritesReportViewSet, FavoritesReportTemplateView

--- a/bangazonapi/views/report.py
+++ b/bangazonapi/views/report.py
@@ -1,14 +1,18 @@
-from django.http import JsonResponse
+from django.http import JsonResponse, HttpResponseRedirect
 from django.views import View
 from bangazonapi.models import Customer, Favorite
 from rest_framework import viewsets
 from rest_framework.response import Response
 import json
+from django.shortcuts import render
+from django.views.generic import TemplateView
+import requests
+from urllib.parse import urlencode
+
 
 class FavoritesReportViewSet(viewsets.ViewSet):
-    def list(self, request, *args, **kwargs):
-        # Assuming you want to filter by a customer ID passed in the query params
-        customer_id = self.request.query_params.get('customer', None)
+    def list(self, request):
+        customer_id = request.query_params.get('customer')
         if not customer_id:
             return Response({"error": "Customer ID is required"}, status=400)
 
@@ -17,11 +21,30 @@ class FavoritesReportViewSet(viewsets.ViewSet):
         except (ValueError, Customer.DoesNotExist):
             return Response({"error": "Invalid customer ID"}, status=400)
 
-        # Fetch and prepare the report data
         favorites = Favorite.objects.filter(customer=customer)
         report_data = {
             "customer_name": f"{customer.user.first_name} {customer.user.last_name}",
             "favorites": [{"seller_name": f"{fav.seller.user.first_name} {fav.seller.user.last_name}"} for fav in favorites]
         }
-
         return Response(report_data)
+
+
+class FavoritesReportTemplateView(TemplateView):
+    template_name = '../templates/reports/favoritesellers.html'
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        customer_id = self.request.GET.get('customer')
+        if not customer_id:
+            context['error'] = "Customer ID is required"
+            return context
+
+        api_url = f"http://localhost:8000/reports/favoritesellers?customer={customer_id}"
+        response = requests.get(api_url)
+        if response.status_code == 200:
+            data = response.json()
+            context['customer_name'] = data.get('customer_name', '')
+            context['favorites'] = data.get('favorites', [])
+        else:
+            context['error'] = "Failed to fetch report."
+        return context

--- a/bangazonapi/views/report.py
+++ b/bangazonapi/views/report.py
@@ -1,0 +1,27 @@
+from django.http import JsonResponse
+from django.views import View
+from bangazonapi.models import Customer, Favorite
+from rest_framework import viewsets
+from rest_framework.response import Response
+import json
+
+class FavoritesReportViewSet(viewsets.ViewSet):
+    def list(self, request, *args, **kwargs):
+        # Assuming you want to filter by a customer ID passed in the query params
+        customer_id = self.request.query_params.get('customer', None)
+        if not customer_id:
+            return Response({"error": "Customer ID is required"}, status=400)
+
+        try:
+            customer = Customer.objects.get(id=int(customer_id))
+        except (ValueError, Customer.DoesNotExist):
+            return Response({"error": "Invalid customer ID"}, status=400)
+
+        # Fetch and prepare the report data
+        favorites = Favorite.objects.filter(customer=customer)
+        report_data = {
+            "customer_name": f"{customer.user.first_name} {customer.user.last_name}",
+            "favorites": [{"seller_name": f"{fav.seller.user.first_name} {fav.seller.user.last_name}"} for fav in favorites]
+        }
+
+        return Response(report_data)


### PR DESCRIPTION
This PR implements a template report at http://localhost:8000/reports/favoritesellers?customer={id} which displays a customer's favorite sellers

## Changes

- Modifies Customer model to add generate_favorites_report method
- Adds views/report.py with FavoritesReportViewSet, FavoritesReportTemplateView
- Modifies url routing
- Creates a favoritesellers.html template in templates/reports/
- Modified to remove dependency to requests library

## Requests / Responses

A request to http://localhost:8000/reports/favoritesellers?customer={customer_id} will return an HTML report in the following form (example customer_id=7):

<img width="308" alt="Screenshot 2024-07-09 at 1 55 58 PM" src="https://github.com/day-cohort-70/Bangazon-API-Spicy-Boys-V2/assets/89662718/b907e115-fc12-4c36-bd45-037e03a51ac3">


## Testing

Description of how to test code...

- [ ] Run migrations
- [ ] Seed database (if necessary to reset)
- [ ] Start API debugger
- [ ] Navigate to http://localhost:8000/reports/favoritesellers?customer=7 to test relationships
- [ ] Navigate to http://localhost:8000/reports/favoritesellers?customer=4 to confirm that Steve has no preferences


## Related Issues

- Fixes #28 