### PR TITLE
Increase max product price to $17,500

### DIFF
--- a/bangazonapi/models/product.py
+++ b/bangazonapi/models/product.py
@@ -18,7 +18,7 @@ class Product(SafeDeleteModel):
         Store, on_delete=models.DO_NOTHING, related_name="products"
     )
     price = models.FloatField(
-        validators=[MinValueValidator(0.00), MaxValueValidator(10000.00)],
+        validators=[MinValueValidator(0.00), MaxValueValidator(17500.00)],
     )
     description = models.CharField(
         max_length=255,


### PR DESCRIPTION
## What?
The max price for a product has been increased from $10,000 to $17,500, meaning a seller can list an item for sale with a price up to $17,500.
## Why?
Sellers wanted the ability to list more expensive products in the store. This change allows them to do that.
## How?
The value of the MaxValueValidator has been changed to 17500.00 in the product model
## Testing?
Test in browser:
-run ```npm run dev``` in client terminal
-make sure api debugger is running
-Click link "Add a New Product" from drop down menu
-Complete product form. ensure the value for price is more than 10000 but less that 175000. Do not include a comma in this field.
-Click save. Check with database that the new product with the correct price has been added. In the browser you may also check to see that the new product was added to the seller's store.
## Screenshots (optional)
0
## Anything Else?
