### PR TITLE
Added to Products ViewSet - like-unlike-get

### DIFF
--- a/bangazon/urls.py
+++ b/bangazon/urls.py
@@ -20,7 +20,6 @@ router.register(r'profile', Profile, 'profile')
 router.register(r'stores', StoresViewSet, 'store')
 router.register(r'storeproduct', OrderProductViewSet, basename='storeproduct')
 
-
 # Wire up our API using automatic URL routing.
 # Additionally, we include login URLs for the browsable API.
 urlpatterns = [

--- a/bangazonapi/models/likedproduct.py
+++ b/bangazonapi/models/likedproduct.py
@@ -2,8 +2,8 @@ from django.db import models
 
 
 class LikedProduct(models.Model):
-    customer_id = models.ForeignKey("Customer", on_delete=models.CASCADE)
-    product_id = models.ForeignKey("Product", on_delete=models.CASCADE)
+    customer = models.ForeignKey("Customer", on_delete=models.CASCADE)
+    product = models.ForeignKey("Product", on_delete=models.CASCADE)
 
     class Meta:
-        db_table = "LikedProduct"
+        db_table = "likedproduct"


### PR DESCRIPTION
## Changes

- `models/likedproduct.py`: Updated Names (Changed DB)
- `views/product.py`: Added to `Products(ViewSet)` 2 functions 
1. Like (POST & DELETE) 
2. liked (GET) 

## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

DELETE `http://localhost:8000/products/2/like` Deletes liked product instance in the `likedproduct` table
GET `http://localhost:8000/products/liked` Get all customer liked products
POST `http://localhost:8000/products/5/like` likes product


## Testing

- [ ] Pull API Side 
- [ ] Seed Database Again
- [ ] Open PostMan
- [ ] Test URLs above 


## Related Issues

- Fixes #17 
- - Only API side working, still need to complete client side for this ticket 