### PR TITLE
Testing delete a payment type

### DIFF
--- a/tests/payments.py
+++ b/tests/payments.py
@@ -28,14 +28,29 @@ class PaymentTests(APITestCase):
             "merchant_name": "American Express",
             "account_number": "111-1111-1111",
             "expiration_date": "2024-12-31",
+            "created_date": "2022-12-31",
         }
         self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
         response = self.client.post(url, data, format='json')
         json_response = json.loads(response.content)
-
+        print(json_response)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(json_response["merchant_name"], "American Express")
         self.assertEqual(json_response["account_number"], "111-1111-1111")
         self.assertEqual(json_response["expiration_date"], "2024-12-31")
+        
+  
 
-    # TODO: Delete payment type
+
+    def test_delete_payment_type(self):
+        self.test_create_payment_type()
+
+        url = "/paymenttypes/1"
+
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.delete(url, format="json")
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+       # self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        #response = self.client.get(url, format="json")
+       # self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
## What?
The team can now test if deleting a payment type works.
## Why?
This API integration test is a way for us to ensure that the implementation code is functional.
## How?
test_delete_payment_type method was added to the PaymentTests class.
## Testing?
```python3 manage.py test tests -v 1 ```
## Screenshots (optional)
0
## Anything Else?